### PR TITLE
fix: update profile database name as "auth"

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/migration/reader/BatchDataReader.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/migration/reader/BatchDataReader.java
@@ -83,7 +83,7 @@ public class BatchDataReader {
     MySqlPagingQueryProvider queryProvider = new MySqlPagingQueryProvider();
     queryProvider.setSelectClause("SELECT * ");
     queryProvider.setFromClause("FROM revalidation.Revalidation reval "
-        + "INNER JOIN profile.TraineeProfile gmc ON reval.tisId = gmc.tisId");
+        + "INNER JOIN auth.TraineeProfile gmc ON reval.tisId = gmc.tisId");
     queryProvider.setSortKeys(sortByCreationDate());
     return queryProvider;
   }


### PR DESCRIPTION
the real name of the profile database is "auth" (although it appears as "profile" on Metabase)

TIS21-2026